### PR TITLE
Fixed typo in definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ In this project, we apply a deep learning model recently developed by Minh et al
 
 ## 2. Background
 
-Reinforcement learning develops control patterns by providing feedback on a model’s selected actions, which encourages the model to select better actions in the future. At each time step, given some state s, the model will select an action s, and then observe the new state s' and a reward r based on some optimality criterion.
+Reinforcement learning develops control patterns by providing feedback on a model’s selected actions, which encourages the model to select better actions in the future. At each time step, given some state s, the model will select an action a, and then observe the new state s' and a reward r based on some optimality criterion.
 
 We specifically used a method known as Q learning, which approximates the maximum expected return for performing an action at a given state using an action-value (Q) function. Specifically, return gives the sum of the rewards until the game terminates, where the reward is discounted by a factor of γ at each time step. We formally define this as:
 


### PR DESCRIPTION
Minor typo, but perhaps confusing for newcomers as it's in the first paragraph of the "Background" section.

All this PR does is change "...select an action s" to the certainly desired "...select an action a".